### PR TITLE
ci: pin qntx/workflows @v2

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,20 @@
+# Caller owns on:. Pin at @v2.
+# Enable "Allow auto-merge" on the repository. This workflow does not approve.
+# If branch protection requires reviews, add a ruleset bypass for dependabot
+# or pass TOKEN (a PAT/App) that can enable auto-merge. Do not checkout the PR.
+name: Dependabot
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: qntx/workflows/.github/workflows/ops-dependabot.yml@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,8 +6,13 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   call-ci:
-    uses: qntx/workflows/.github/workflows/python.yml@main
+    uses: qntx/workflows/.github/workflows/ci-python.yml@v2
+    permissions:
+      contents: read
     with:
       python-version: '3.13'

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -5,10 +5,15 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   call-publish:
-    uses: qntx/workflows/.github/workflows/python-publish.yml@main
+    uses: qntx/workflows/.github/workflows/publish-pypi.yml@v2.0.0
+    permissions:
+      contents: read
     with:
       python-version: '3.13'
     secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN || secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,13 @@ on:
     - cron: "30 1 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   close-stale:
-    uses: qntx/workflows/.github/workflows/stale.yml@main
+    uses: qntx/workflows/.github/workflows/ops-stale.yml@v2
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
Mechanical cutover to qntx/workflows @v2 / @v2.0.0 per docs/MIGRATION.md. No application code.

- `python.yml` → `ci-python.yml@v2`
- `python_publish.yml` → `publish-pypi.yml@v2.0.0` (token-only; maps `PYPI_TOKEN` or legacy `PYPI_API_TOKEN`)
- `stale.yml` → `ops-stale.yml@v2` (job id `close-stale` kept)
- add Dependabot auto-merge caller

Repo auto-merge enabled for Dependabot patch/minor only. This PR is not auto-merged.