### PR TITLE
fix(ci): run Dependabot sweep daily

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,12 +1,12 @@
 # Caller owns on:. Pin at @v2.
 # schedule / workflow_dispatch squash-merge green Dependabot PRs.
-# Public cron is */15 * * * *. Private callers use 0 */6 * * *.
+# Daily cron 0 4 * * * (04:00 UTC).
 # Do not checkout the PR. Does not approve.
 name: Dependabot
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Dependabot sweep cron is daily `0 4 * * *` (04:00 UTC).
- Replaces `*/15` (public) and `0 */6` (private). Merge-when-green does not need 15-minute polling.

## Test plan
- [ ] CI green (formatter must keep this file's existing cron quoting)
