### PR TITLE
feat: add local Monad exact and upto examples

### DIFF
--- a/examples/local_monad_exact.py
+++ b/examples/local_monad_exact.py
@@ -14,6 +14,8 @@ import json
 import os
 from pathlib import Path
 
+from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
+
 
 def _load_dotenv() -> None:
     path = Path(__file__).resolve().parents[1] / ".env"
@@ -30,8 +32,6 @@ def _load_dotenv() -> None:
 _load_dotenv()
 os.environ.setdefault("NO_PROXY", "127.0.0.1,localhost,::1")
 os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
-
-from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
 
 network = os.environ.get("NETWORK", "eip155:143")
 rpc_url = "https://testnet-rpc.monad.xyz" if network == "eip155:10143" else "https://rpc.monad.xyz"

--- a/examples/local_monad_exact.py
+++ b/examples/local_monad_exact.py
@@ -1,0 +1,76 @@
+"""Local o402 exact settlement on Monad (mainnet or testnet).
+
+Hits POST /v1/images/generations (o402 bills that path exact) against the
+local echo upstream (`exact-echo`).
+
+Usage:
+  python examples/local_monad_exact.py
+  NETWORK=eip155:10143 python examples/local_monad_exact.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def _load_dotenv() -> None:
+    path = Path(__file__).resolve().parents[1] / ".env"
+    if not path.is_file():
+        return
+    for line in path.read_text().splitlines():
+        raw = line.strip()
+        if not raw or raw.startswith("#") or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        os.environ.setdefault(key, value)
+
+
+_load_dotenv()
+os.environ.setdefault("NO_PROXY", "127.0.0.1,localhost,::1")
+os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
+
+from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
+
+network = os.environ.get("NETWORK", "eip155:143")
+rpc_url = (
+    "https://testnet-rpc.monad.xyz"
+    if network == "eip155:10143"
+    else "https://rpc.monad.xyz"
+)
+client = X402OpenAI(
+    evm=EvmConfig(private_key=os.environ["EVM_PRIVATE_KEY"], rpc_url=rpc_url),
+    base_url=os.environ.get("O402_BASE_URL", "http://127.0.0.1:8080/v1"),
+    api_key="x402",
+    max_retries=0,
+    spend_controls={
+        "max_amount_per_payment": "$1",
+        "allowed_assets": [
+            {
+                "network": "eip155:10143",
+                "asset": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+            }
+        ],
+    },
+    policies=[prefer_network(network), prefer_scheme("exact")],
+)
+
+image = client.images.generate(
+    model="exact-echo",
+    prompt=f"exact {network}",
+    n=1,
+    size="256x256",
+)
+print(
+    json.dumps(
+        {
+            "network": network,
+            "model": "exact-echo",
+            "scheme": "exact",
+            "created": image.created,
+            "url": None if not image.data else image.data[0].url,
+        },
+        indent=2,
+    )
+)

--- a/examples/local_monad_exact.py
+++ b/examples/local_monad_exact.py
@@ -34,11 +34,7 @@ os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
 from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
 
 network = os.environ.get("NETWORK", "eip155:143")
-rpc_url = (
-    "https://testnet-rpc.monad.xyz"
-    if network == "eip155:10143"
-    else "https://rpc.monad.xyz"
-)
+rpc_url = "https://testnet-rpc.monad.xyz" if network == "eip155:10143" else "https://rpc.monad.xyz"
 client = X402OpenAI(
     evm=EvmConfig(private_key=os.environ["EVM_PRIVATE_KEY"], rpc_url=rpc_url),
     base_url=os.environ.get("O402_BASE_URL", "http://127.0.0.1:8080/v1"),

--- a/examples/local_monad_matrix.py
+++ b/examples/local_monad_matrix.py
@@ -35,9 +35,7 @@ networks = ("eip155:143", "eip155:10143")
 
 def rpc_url(network: str) -> str:
     return (
-        "https://testnet-rpc.monad.xyz"
-        if network == "eip155:10143"
-        else "https://rpc.monad.xyz"
+        "https://testnet-rpc.monad.xyz" if network == "eip155:10143" else "https://rpc.monad.xyz"
     )
 
 
@@ -72,7 +70,7 @@ for network in networks:
             stream=False,
         )
         print("upto ok", {"network": network, "content": chat.choices[0].message.content})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         print("upto fail", network, type(exc).__name__, exc)
 
     try:
@@ -84,5 +82,5 @@ for network in networks:
         )
         url = None if not image.data else image.data[0].url
         print("exact ok", {"network": network, "url": url})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         print("exact fail", network, type(exc).__name__, exc)

--- a/examples/local_monad_matrix.py
+++ b/examples/local_monad_matrix.py
@@ -1,0 +1,88 @@
+"""Exercise exact + upto on Monad mainnet and testnet against local o402.
+
+Usage: python examples/local_monad_matrix.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _load_dotenv() -> None:
+    path = Path(__file__).resolve().parents[1] / ".env"
+    if not path.is_file():
+        return
+    for line in path.read_text().splitlines():
+        raw = line.strip()
+        if not raw or raw.startswith("#") or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        os.environ.setdefault(key, value)
+
+
+_load_dotenv()
+os.environ.setdefault("NO_PROXY", "127.0.0.1,localhost,::1")
+os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
+
+from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
+
+key = os.environ["EVM_PRIVATE_KEY"]
+base_url = os.environ.get("O402_BASE_URL", "http://127.0.0.1:8080/v1")
+chat_model = os.environ.get("MODEL", "openrouter/meta-llama/llama-3.1-8b-instruct")
+networks = ("eip155:143", "eip155:10143")
+
+
+def rpc_url(network: str) -> str:
+    return (
+        "https://testnet-rpc.monad.xyz"
+        if network == "eip155:10143"
+        else "https://rpc.monad.xyz"
+    )
+
+
+def make_client(network: str, scheme: str) -> X402OpenAI:
+    return X402OpenAI(
+        evm=EvmConfig(private_key=key, rpc_url=rpc_url(network)),
+        base_url=base_url,
+        api_key="x402",
+        max_retries=0,
+        spend_controls={
+            "max_amount_per_payment": "$1",
+            "allowed_assets": [
+                {
+                    "network": "eip155:10143",
+                    "asset": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+                }
+            ],
+        },
+        policies=[prefer_network(network), prefer_scheme(scheme)],
+    )
+
+
+unpaid = X402OpenAI(evm=key, base_url=base_url, api_key="x402", max_retries=0)
+print("models", [model.id for model in unpaid.models.list().data[:12]])
+
+for network in networks:
+    try:
+        chat = make_client(network, "upto").chat.completions.create(
+            model=chat_model,
+            messages=[{"role": "user", "content": f"One word for {network}"}],
+            max_tokens=8,
+            stream=False,
+        )
+        print("upto ok", {"network": network, "content": chat.choices[0].message.content})
+    except Exception as exc:  # noqa: BLE001
+        print("upto fail", network, type(exc).__name__, exc)
+
+    try:
+        image = make_client(network, "exact").images.generate(
+            model="exact-echo",
+            prompt=f"exact {network}",
+            n=1,
+            size="256x256",
+        )
+        url = None if not image.data else image.data[0].url
+        print("exact ok", {"network": network, "url": url})
+    except Exception as exc:  # noqa: BLE001
+        print("exact fail", network, type(exc).__name__, exc)

--- a/examples/local_monad_matrix.py
+++ b/examples/local_monad_matrix.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
+
 
 def _load_dotenv() -> None:
     path = Path(__file__).resolve().parents[1] / ".env"
@@ -24,8 +26,6 @@ def _load_dotenv() -> None:
 _load_dotenv()
 os.environ.setdefault("NO_PROXY", "127.0.0.1,localhost,::1")
 os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
-
-from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
 
 key = os.environ["EVM_PRIVATE_KEY"]
 base_url = os.environ.get("O402_BASE_URL", "http://127.0.0.1:8080/v1")

--- a/examples/local_monad_upto.py
+++ b/examples/local_monad_upto.py
@@ -1,0 +1,74 @@
+"""Local o402 upto chat on Monad (mainnet or testnet).
+
+Usage:
+  python examples/local_monad_upto.py
+  NETWORK=eip155:10143 python examples/local_monad_upto.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def _load_dotenv() -> None:
+    path = Path(__file__).resolve().parents[1] / ".env"
+    if not path.is_file():
+        return
+    for line in path.read_text().splitlines():
+        raw = line.strip()
+        if not raw or raw.startswith("#") or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        os.environ.setdefault(key, value)
+
+
+_load_dotenv()
+os.environ.setdefault("NO_PROXY", "127.0.0.1,localhost,::1")
+os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
+
+from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
+
+network = os.environ.get("NETWORK", "eip155:143")
+rpc_url = (
+    "https://testnet-rpc.monad.xyz"
+    if network == "eip155:10143"
+    else "https://rpc.monad.xyz"
+)
+client = X402OpenAI(
+    evm=EvmConfig(private_key=os.environ["EVM_PRIVATE_KEY"], rpc_url=rpc_url),
+    base_url=os.environ.get("O402_BASE_URL", "http://127.0.0.1:8080/v1"),
+    api_key="x402",
+    max_retries=0,
+    spend_controls={
+        "max_amount_per_payment": "$1",
+        "allowed_assets": [
+            {
+                "network": "eip155:10143",
+                "asset": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+            }
+        ],
+    },
+    policies=[prefer_network(network), prefer_scheme("upto")],
+)
+
+model = os.environ.get("MODEL", "openrouter/meta-llama/llama-3.1-8b-instruct")
+response = client.chat.completions.create(
+    model=model,
+    messages=[{"role": "user", "content": f"Reply with one word: {network}"}],
+    max_tokens=16,
+    stream=False,
+)
+print(
+    json.dumps(
+        {
+            "network": network,
+            "model": model,
+            "scheme": "upto",
+            "content": response.choices[0].message.content,
+            "usage": None if response.usage is None else response.usage.model_dump(),
+        },
+        indent=2,
+    )
+)

--- a/examples/local_monad_upto.py
+++ b/examples/local_monad_upto.py
@@ -31,11 +31,7 @@ os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
 from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
 
 network = os.environ.get("NETWORK", "eip155:143")
-rpc_url = (
-    "https://testnet-rpc.monad.xyz"
-    if network == "eip155:10143"
-    else "https://rpc.monad.xyz"
-)
+rpc_url = "https://testnet-rpc.monad.xyz" if network == "eip155:10143" else "https://rpc.monad.xyz"
 client = X402OpenAI(
     evm=EvmConfig(private_key=os.environ["EVM_PRIVATE_KEY"], rpc_url=rpc_url),
     base_url=os.environ.get("O402_BASE_URL", "http://127.0.0.1:8080/v1"),

--- a/examples/local_monad_upto.py
+++ b/examples/local_monad_upto.py
@@ -11,6 +11,8 @@ import json
 import os
 from pathlib import Path
 
+from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
+
 
 def _load_dotenv() -> None:
     path = Path(__file__).resolve().parents[1] / ".env"
@@ -27,8 +29,6 @@ def _load_dotenv() -> None:
 _load_dotenv()
 os.environ.setdefault("NO_PROXY", "127.0.0.1,localhost,::1")
 os.environ.setdefault("no_proxy", os.environ["NO_PROXY"])
-
-from x402_openai import EvmConfig, X402OpenAI, prefer_network, prefer_scheme
 
 network = os.environ.get("NETWORK", "eip155:143")
 rpc_url = "https://testnet-rpc.monad.xyz" if network == "eip155:10143" else "https://rpc.monad.xyz"


### PR DESCRIPTION
## 中文

### 问题

本地要把 o402 + facilitator 在 Monad 主网（`eip155:143`）和测试网（`eip155:10143`）上跑通 **exact** 和 **upto**。已有 `chat_evm.py` / `chat_upto.py`：

1. 默认 `base_url` 是生产 `https://llm.qntx.org/v1`。
2. 没有 `prefer_network`，会付 402 的第一条（主网）。
3. Python `x402` 的 default assets **没有** Monad 测试网 USDC。默认 spend controls 丢掉测试网 accept 后，`prefer_network("eip155:10143")` passthrough，测试网请求实际 settle 在主网。
4. o402 对 `POST /v1/chat/completions` 记 **upto**；exact 要走 `/v1/images/generations`。
5. 本机若有系统代理，httpx 打 `127.0.0.1` 会 `RemoteProtocolError`。必须 `NO_PROXY=127.0.0.1,localhost,::1`。

### 为什么要改

需要和 TS 包对称的本地矩阵。测试网 USDC 必须写进 `spend_controls.allowed_assets`。`EvmConfig.rpc_url` 按网切换。密钥只从 `.env` / 环境变量读。

### 改动

- `examples/local_monad_upto.py`
- `examples/local_monad_exact.py`（`images.generate` → exact）
- `examples/local_monad_matrix.py`
- 允许测试网 USDC；示例内 `setdefault` `NO_PROXY`。

### 用法

```bash
NO_PROXY=127.0.0.1,localhost,::1 python examples/local_monad_upto.py
NETWORK=eip155:10143 python examples/local_monad_exact.py
```

`.env` 已被 gitignore，不要提交私钥。

---

## English

### Problem

Local o402 + facilitator must exercise **exact** and **upto** on Monad mainnet (`eip155:143`) and testnet (`eip155:10143`). Existing `chat_evm.py` / `chat_upto.py`:

1. Default `base_url` is production `https://llm.qntx.org/v1`.
2. No `prefer_network`, so `accepts[0]` (mainnet) wins.
3. Python `x402` default assets omit Monad testnet USDC. Spend controls drop it; `prefer_network("eip155:10143")` passthrough-pays mainnet.
4. o402 bills chat completions as **upto**. Exact needs `/v1/images/generations`.
5. A system HTTP proxy makes httpx to `127.0.0.1` raise `RemoteProtocolError`. `NO_PROXY=127.0.0.1,localhost,::1` is required.

### Why this change

Parity with the TS package: two nets × two schemes, keys from env, testnet USDC in `spend_controls.allowed_assets`, per-net `EvmConfig.rpc_url`.

### Changes

- `examples/local_monad_upto.py`
- `examples/local_monad_exact.py` (`images.generate` → exact)
- `examples/local_monad_matrix.py`
- Allow testnet USDC; `setdefault` `NO_PROXY` in the examples.

### Usage

```bash
NO_PROXY=127.0.0.1,localhost,::1 python examples/local_monad_upto.py
NETWORK=eip155:10143 python examples/local_monad_exact.py
```

`.env` is gitignored. Do not commit keys.
